### PR TITLE
Clarify package scope

### DIFF
--- a/marcopolo.el
+++ b/marcopolo.el
@@ -1,4 +1,4 @@
-;;; marcopolo.el --- Emacs client for Docker API
+;;; marcopolo.el --- Emacs client to the Docker HUB API
 
 ;; Author: Nicolas Lamirault <nicolas.lamirault@gmail.com>
 ;; URL: https://github.com/nlamirault/marcopolo
@@ -26,7 +26,7 @@
 
 ;;; Commentary:
 
-;; Provides a Docker API client for Emacs.
+;; Provides a Docker HUB API client for Emacs.
 
 ;;; Installation:
 


### PR DESCRIPTION
Hello!

I'm the author of https://github.com/Silex/docker.el and https://github.com/Silex/docker-api.el and I'll soon push the later to MELPA. It is an emacs implementation of https://docs.docker.com/engine/reference/api/docker_remote_api/

Your package http://melpa.org/#/marcopolo currently has as a description `Provides a Docker API client for Emacs`, which I think might be a bit confusing for users because this is what `docker-api.el` is.

If I understood correctly, your package is for the Docker HUB api, am I right? Anyway, my PR attemps to remove the ambiguity :-)