### PR TITLE
No longer provide a feature in test-helper.el

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -103,8 +103,4 @@
           (setup-marcopolo)
           ,@body))))
 
-
-
-
-(provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
**Note that unlike for most of the other pull requests I just opened I
was not able to run the tests for this package.  I get an error about
marmalade not being available when running `cask install`.**

The file isn't a library intended to be loaded with `require`.
Instead `ert-runner` loads it using `load`.  Other packages that
use `ert-runner` also come with a file named test-helper.el and
unfortunately many of those also provide `test-helper`, which
leads to conflicts.